### PR TITLE
Add gulp and automated testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 ._*
+node_modules
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # wapuufall
+
+## How to update snowfall.
+
+```
+$ npm install
+$ npm run build
+```
+
+## Automated testing
+
+```
+$ npm test
+```
+
+Or you can tests on your browser.
+
+```
+$ npm start
+```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var gulp = require( "gulp" );
+var qunit = require( "gulp-qunit" );
+
+gulp.task('test', function() {
+    return gulp.src( './tests/tests.html' )
+        .pipe( qunit() );
+});
+
+gulp.task( 'default', [], function () {
+  return gulp.src( [ './node_modules/JQuery-Snowfall/src/snowfall.jquery.js' ] )
+    .pipe( gulp.dest( 'js' ) );
+} );

--- a/js/snowfall.jquery.js
+++ b/js/snowfall.jquery.js
@@ -144,14 +144,14 @@ if (!Date.now)
                 }
 
                 $(flakeMarkup).attr({
-                    'class': 'snowfall-flakes', 
+                    'class': 'snowfall-flakes',
                 }).css({
-                    'width' : this.size, 
-                    'height' : this.size, 
-                    'position' : options.flakePosition, 
-                    'top' : this.y, 
-                    'left' : this.x, 
-                    'fontSize' : 0, 
+                    'width' : this.size,
+                    'height' : this.size,
+                    'position' : options.flakePosition,
+                    'top' : this.y,
+                    'left' : this.x,
+                    'fontSize' : 0,
                     'zIndex' : options.flakeIndex
                 });
 
@@ -197,7 +197,7 @@ if (!Date.now)
                                             this.speed *= .5;
                                         }
 
-                                        ctx.fillStyle = "#fff";
+                                        ctx.fillStyle = defaults.flakeColor;
 
                                         if(colData[parseInt(curX)][parseInt(curY+this.speed+this.size)] == undefined){
                                             colData[parseInt(curX)][parseInt(curY+this.speed+this.size)] = 1;
@@ -220,7 +220,7 @@ if (!Date.now)
                                             this.x--;
                                         }else{
                                             //stop
-                                            ctx.fillStyle = "#fff";
+                                            ctx.fillStyle = defaults.flakeColor;
                                             ctx.fillRect(curX, curY, this.size, this.size);
                                             colData[parseInt(curX)][parseInt(curY)] = 1;
                                             this.reset();
@@ -288,11 +288,11 @@ if (!Date.now)
                                 }
 
                                 canvasCollection.push({
-                                    element : $canvas.get(0), 
-                                    x : bounds.left, 
-                                    y : bounds.top-collectionHeight, 
-                                    width : bounds.width, 
-                                    height: collectionHeight, 
+                                    element : $canvas.get(0),
+                                    x : bounds.left,
+                                    y : bounds.top-collectionHeight,
+                                    width : bounds.width,
+                                    height: collectionHeight,
                                     colData : collisionData
                                 });
                             }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "wapuufall",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "build": "node_modules/.bin/gulp && npm test",
+    "test": "node_modules/.bin/gulp test",
+    "start": "node_modules/.bin/http-server -c1 -o"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+hhttps://github.com/TickleCode/wapuufall.git"
+  },
+  "author": "",
+  "license": "GPLv2",
+  "bugs": {
+    "url": "https://github.com/TickleCode/wapuufall/issues"
+  },
+  "homepage": "https://github.com/TickleCode/wapuufall#readme",
+  "dependencies": {
+    "JQuery-Snowfall": "git+https://github.com/loktar00/JQuery-Snowfall.git"
+  },
+  "devDependencies": {
+    "gulp": "^3.9.1",
+    "gulp-qunit": "^1.3.1",
+    "http-server": "^0.9.0",
+    "qunit": "^0.9.0"
+  }
+}

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -21,7 +21,6 @@
   <script type="text/javascript" src="../js/wapuufall.js"></script>
   <script type='text/javascript' src='http://code.jquery.com/qunit/qunit-1.12.0.js'></script>
   <script type="text/javascript">
-    var wapuufall_plugin_url = "..";
     test( 'Wapuu should be many!', function() {
         ok( 0 < jQuery( '.snowfall-flakes' ).length, 'Can\'t find Wapuus' );
     } );

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Tests for Wapuufall</title>
+  <style>
+    html, body
+    {
+      width: 100%;
+      height: 100%;
+    }
+  </style>
+</head>
+<body>
+  <div id="qunit"></div>
+  <div id="qunit-fixture"></div>
+  <script type="text/javascript">
+    var wapuufall_plugin_url = "..";
+  </script>
+  <script   src="https://code.jquery.com/jquery-2.2.1.min.js"   integrity="sha256-gvQgAFzTH6trSrAWoH1iPo9Xc96QxSZ3feW6kem+O00="   crossorigin="anonymous"></script>
+  <script type="text/javascript" src="../js/snowfall.jquery.js"></script>
+  <script type="text/javascript" src="../js/wapuufall.js"></script>
+  <script type='text/javascript' src='http://code.jquery.com/qunit/qunit-1.12.0.js'></script>
+  <script type="text/javascript">
+    var wapuufall_plugin_url = "..";
+    test( 'Wapuu should be many!', function() {
+        ok( 0 < jQuery( '.snowfall-flakes' ).length, 'Can\'t find Wapuus' );
+    } );
+  </script>
+</body>
+</html>


### PR DESCRIPTION
ご利益

* Snowfall本体のアップデートをいちいち確認しなくても`npm install && npm run build`だけで勝手に最新にしてくれる。（ていうか今のやり方だとアップデートする気ないですよね？w）
* わぷーが落ちてきているかどうかの確認は、`npm test`と叩くだけでオッケー。ブラウザもWordPressもいらない。
* もしブラウザで確認したければ、`npm start`でオッケー。動作確認にWordPressは不要。